### PR TITLE
Specify license in gem metadata

### DIFF
--- a/ast-tdl.gemspec
+++ b/ast-tdl.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "ast-tdl"
   spec.version       = "0.0.2"
+  spec.license       = "MIT"
   spec.authors       = ["firefly-cpp", "luckyLukac"]
   spec.email         = ["iztok@iztok-jr-fister.eu", "luka.lukac@student.um.si"]
 


### PR DESCRIPTION
This is good practice, and fixes the following warning:

```
$ gem build ast-tdl.gemspec
WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
```