### PR TITLE
Include the license file in the gem

### DIFF
--- a/ast-tdl.gemspec
+++ b/ast-tdl.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.files = [
+    'LICENSE',
     'README.md',
     'lib/ast.rb',
     'lib/classes.rb',


### PR DESCRIPTION
The chosen MIT license requires its text to be included with all distributions of the software.